### PR TITLE
OpenTelemetry tracing support

### DIFF
--- a/liflig-messaging-awssdk/src/main/kotlin/no/liflig/messaging/awssdk/queue/SqsQueue.kt
+++ b/liflig-messaging-awssdk/src/main/kotlin/no/liflig/messaging/awssdk/queue/SqsQueue.kt
@@ -2,6 +2,9 @@
 
 package no.liflig.messaging.awssdk.queue
 
+import io.opentelemetry.api.GlobalOpenTelemetry
+import io.opentelemetry.context.Context
+import io.opentelemetry.context.propagation.TextMapGetter
 import java.time.Duration
 import no.liflig.logging.getLogger
 import no.liflig.messaging.Message
@@ -149,5 +152,32 @@ internal fun sqsMessageToInternalFormat(sqsMessage: SQSMessage, source: String):
       systemAttributes = sqsMessage.attributesAsStrings() ?: emptyMap(),
       customAttributes = customAttributes,
       source = source,
+      context = sqsMessage.extractContext(),
   )
+}
+
+/**
+ * Attempt to pull trace context from `AWSTraceHeader`.
+ *
+ * This function tries to extract an OpenTelemetry Context using the
+ * [io.opentelemetry.context.propagation.TextMapPropagator]s that are registered in the global OTEL
+ * instance. If no X-Ray propagator is registered, for instance if no OTEL java agent is attached to
+ * the JVM, it will return the bare root context.
+ *
+ * If no trace header is present, we return null and leave it up to the caller to decide whether to
+ * initiate a new trace.
+ */
+internal fun SQSMessage.extractContext(): Context? {
+  val header = this.attributes()[MessageSystemAttributeName.AWS_TRACE_HEADER] ?: return null
+
+  val propagator = GlobalOpenTelemetry.getOrNoop().propagators.textMapPropagator
+
+  val getter =
+      object : TextMapGetter<Map<String, String>> {
+        override fun keys(carrier: Map<String, String>): Iterable<String?> = carrier.keys
+
+        override fun get(carrier: Map<String, String>?, key: String): String? = carrier?.get(key)
+      }
+
+  return propagator.extract(Context.root(), mapOf("X-Amzn-Trace-Id" to header), getter)
 }

--- a/liflig-messaging-core/src/main/kotlin/no/liflig/messaging/Message.kt
+++ b/liflig-messaging-core/src/main/kotlin/no/liflig/messaging/Message.kt
@@ -1,5 +1,6 @@
 package no.liflig.messaging
 
+import io.opentelemetry.context.Context
 import java.time.Instant
 
 public data class Message(
@@ -47,6 +48,13 @@ public data class Message(
      *   event (through the `eventSourceArn` field)
      */
     val source: String? = null,
+    /**
+     * An OpenTelemetry trace context. Populate this if the originating queue supports propagating
+     * trace context.
+     *
+     * See [no.liflig.messaging.observability.OpenTelemetryMessagePollerObserver]
+     */
+    val context: Context? = null,
 ) {
   /**
    * In AWS SQS, the message's [systemAttributes] contain a `SentTimestamp` with the time that the

--- a/liflig-messaging-core/src/main/kotlin/no/liflig/messaging/MessagePollerObserver.kt
+++ b/liflig-messaging-core/src/main/kotlin/no/liflig/messaging/MessagePollerObserver.kt
@@ -12,16 +12,16 @@ import no.liflig.logging.withLoggingContext
  */
 public interface MessagePollerObserver {
   /** Called when [MessagePoller] starts up. */
-  public fun onPollerStartup()
+  public fun onPollerStartup(): Unit = Unit
 
   /** Called when [MessagePoller] polls messages from its queue. */
-  public fun onPoll(messages: List<Message>)
+  public fun onPoll(messages: List<Message>): Unit = Unit
 
   /** Called when an exception is thrown when [MessagePoller] polls from its queue. */
-  public fun onPollException(exception: Throwable)
+  public fun onPollException(exception: Throwable): Unit = Unit
 
   /** Called by [MessagePoller.close]. */
-  public fun onPollerShutdown()
+  public fun onPollerShutdown(): Unit = Unit
 
   /**
    * Called when a [MessagePoller] thread detects that it has been interrupted. This is typically
@@ -30,7 +30,7 @@ public interface MessagePollerObserver {
    * @param cause If the thread detected interruption in the context of an exception, it is passed
    *   here.
    */
-  public fun onPollerThreadStopped(cause: Throwable?)
+  public fun onPollerThreadStopped(cause: Throwable?): Unit = Unit
 
   /**
    * Called when [MessagePoller] starts processing a message, before passing it to the
@@ -38,34 +38,34 @@ public interface MessagePollerObserver {
    *
    * This is called inside the scope of [wrapMessageProcessing].
    */
-  public fun onMessageProcessing(message: Message)
+  public fun onMessageProcessing(message: Message): Unit = Unit
 
   /**
    * Called when [MessageProcessor] returns [ProcessingResult.Success].
    *
    * This is called inside the scope of [wrapMessageProcessing].
    */
-  public fun onMessageSuccess(message: Message)
+  public fun onMessageSuccess(message: Message): Unit = Unit
 
   /**
    * Called when [MessageProcessor] returns [ProcessingResult.Failure].
    *
    * This is called inside the scope of [wrapMessageProcessing].
    */
-  public fun onMessageFailure(message: Message, result: ProcessingResult.Failure)
+  public fun onMessageFailure(message: Message, result: ProcessingResult.Failure): Unit = Unit
 
   /**
    * Called when [MessageProcessor] throws an exception while processing a message.
    *
    * This is called inside the scope of [wrapMessageProcessing].
    */
-  public fun onMessageException(message: Message, exception: Throwable)
+  public fun onMessageException(message: Message, exception: Throwable): Unit = Unit
 
   /**
    * Wraps [MessagePoller]'s code for processing the given message (including the call to
    * [MessageProcessor.process]). This allows you to add scope-based context to the message
-   * processing. For example, [DefaultMessagePollerObserver] uses
-   * [no.liflig.logging.withLoggingContext] to add the queue message ID to the logging context.
+   * processing. For example, [DefaultMessagePollerObserver] uses [withLoggingContext] to add the
+   * queue message ID to the logging context.
    *
    * The implementation of this method MUST call the given [messageProcessingBlock] once, and only
    * once.
@@ -76,15 +76,14 @@ public interface MessagePollerObserver {
   public fun <ReturnT> wrapMessageProcessing(
       message: Message,
       messageProcessingBlock: () -> ReturnT,
-  ): ReturnT
+  ): ReturnT = messageProcessingBlock()
 
   /**
    * Wraps [MessagePoller]'s main polling loop (including message processing), as well as startup
    * and shutdown. This allows you to add scope-based context to the whole lifetime of a message
    * poller (the given [pollerBlock] will not exit until the poller is closed). For example,
-   * [DefaultMessagePollerObserver] uses [no.liflig.logging.withLoggingContext] to add the message
-   * poller name to the logging context, so users can distinguish between logs from different
-   * pollers.
+   * [DefaultMessagePollerObserver] uses [withLoggingContext] to add the message poller name to the
+   * logging context, so users can distinguish between logs from different pollers.
    *
    * The implementation of this method MUST call the given [pollerBlock] once, and only once.
    *
@@ -93,16 +92,15 @@ public interface MessagePollerObserver {
    * @return The same type as the given [pollerBlock] (so you must return the result of calling the
    *   lambda).
    */
-  public fun <ReturnT> wrapPoller(pollerBlock: () -> ReturnT): ReturnT
+  public fun <ReturnT> wrapPoller(pollerBlock: () -> ReturnT): ReturnT = pollerBlock()
 }
 
 /**
  * Default implementation of [MessagePollerObserver], using `liflig-logging` to log descriptive
  * messages for the various events in [MessagePoller]'s polling loop.
  *
- * [wrapMessageProcessing] uses [no.liflig.logging.withLoggingContext] to add a `queueMessageId`
- * field to all logs in the scope of processing the message, so you can trace the logs for a
- * specific message.
+ * [wrapMessageProcessing] uses [withLoggingContext] to add a `queueMessageId` field to all logs in
+ * the scope of processing the message, so you can trace the logs for a specific message.
  *
  * If you want a quieter observer that only logs in case of failure, you may want to use
  * [QuietMessagePollerObserver] instead.
@@ -229,3 +227,49 @@ public open class QuietMessagePollerObserver(
 
   override fun onMessageSuccess(message: Message) {}
 }
+
+/**
+ * Observer that calls each of its delegates in order. Wrapping methods are nested in order, with
+ * the first delegate applied first.
+ */
+internal class ChainedMessagePollerObserver(private val delegates: List<MessagePollerObserver>) :
+    MessagePollerObserver {
+  override fun onPollerStartup(): Unit = delegates.forEach { it.onPollerStartup() }
+
+  override fun onPoll(messages: List<Message>): Unit = delegates.forEach { it.onPoll(messages) }
+
+  override fun onPollException(exception: Throwable): Unit =
+      delegates.forEach { it.onPollException(exception) }
+
+  override fun onPollerShutdown(): Unit = delegates.forEach { it.onPollerShutdown() }
+
+  override fun onPollerThreadStopped(cause: Throwable?): Unit =
+      delegates.forEach { it.onPollerThreadStopped(cause) }
+
+  override fun onMessageProcessing(message: Message): Unit =
+      delegates.forEach { it.onMessageProcessing(message) }
+
+  override fun onMessageSuccess(message: Message): Unit =
+      delegates.forEach { it.onMessageSuccess(message) }
+
+  override fun onMessageFailure(message: Message, result: ProcessingResult.Failure): Unit =
+      delegates.forEach { it.onMessageFailure(message, result) }
+
+  override fun onMessageException(message: Message, exception: Throwable): Unit =
+      delegates.forEach { it.onMessageException(message, exception) }
+
+  override fun <ReturnT> wrapMessageProcessing(
+      message: Message,
+      messageProcessingBlock: () -> ReturnT,
+  ): ReturnT =
+      delegates.foldRight(messageProcessingBlock) { observer, acc ->
+        { observer.wrapMessageProcessing(message, acc) }
+      }()
+
+  override fun <ReturnT> wrapPoller(pollerBlock: () -> ReturnT): ReturnT =
+      delegates.foldRight(pollerBlock) { observer, acc -> { observer.wrapPoller(acc) } }()
+}
+
+/** Chains [MessagePollerObserver]s together in order. */
+public fun chained(vararg delegates: MessagePollerObserver): MessagePollerObserver =
+    ChainedMessagePollerObserver(delegates.toList())

--- a/liflig-messaging-core/src/main/kotlin/no/liflig/messaging/observability/OpenTelemetryMessagePollerObserver.kt
+++ b/liflig-messaging-core/src/main/kotlin/no/liflig/messaging/observability/OpenTelemetryMessagePollerObserver.kt
@@ -1,0 +1,62 @@
+package no.liflig.messaging.observability
+
+import io.opentelemetry.api.GlobalOpenTelemetry
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.api.trace.StatusCode
+import io.opentelemetry.context.Context
+import no.liflig.messaging.Message
+import no.liflig.messaging.MessagePollerObserver
+import no.liflig.messaging.ProcessingResult
+
+/**
+ * Pulls OpenTelemetry context from polled messages and wraps message processing in an appropriate
+ * span.
+ */
+public class OpenTelemetryMessagePollerObserver(
+    private val queueName: String,
+    private val pollerName: String,
+) : MessagePollerObserver {
+  private val destinationNameKey = AttributeKey.stringKey("messaging.destination.name")
+  private val messageIdKey = AttributeKey.stringKey("messaging.message.id")
+  private val operationNameKey = AttributeKey.stringKey("messaging.operation.name")
+  private val operationTypeKey = AttributeKey.stringKey("messaging.operation.type")
+  private val clientKey = AttributeKey.stringKey("messaging.client.id")
+
+  private val tracer = GlobalOpenTelemetry.getTracer("liflig-messaging")
+
+  override fun onMessageSuccess(message: Message) {
+    Span.current().setStatus(StatusCode.OK)
+  }
+
+  override fun onMessageFailure(message: Message, result: ProcessingResult.Failure) {
+    val span = Span.current()
+    span.setStatus(StatusCode.ERROR)
+    result.cause?.let { span.recordException(it) }
+  }
+
+  override fun <ReturnT> wrapMessageProcessing(
+      message: Message,
+      messageProcessingBlock: () -> ReturnT,
+  ): ReturnT {
+    val context = message.context ?: Context.root()
+    val span =
+        tracer
+            .spanBuilder("process $queueName")
+            .setParent(context)
+            .setSpanKind(SpanKind.CONSUMER)
+            .setAttribute(destinationNameKey, queueName)
+            .setAttribute(messageIdKey, message.id.value)
+            .setAttribute(operationNameKey, "process")
+            .setAttribute(operationTypeKey, "process")
+            .setAttribute(clientKey, pollerName)
+            .startSpan()
+
+    try {
+      return span.makeCurrent().use { messageProcessingBlock() }
+    } finally {
+      span.end()
+    }
+  }
+}

--- a/liflig-messaging-core/src/test/kotlin/no/liflig/messaging/utils/ChainedMessageObserverTest.kt
+++ b/liflig-messaging-core/src/test/kotlin/no/liflig/messaging/utils/ChainedMessageObserverTest.kt
@@ -1,0 +1,91 @@
+package no.liflig.messaging.utils
+
+import io.mockk.spyk
+import io.mockk.verifyOrder
+import no.liflig.messaging.Message
+import no.liflig.messaging.MessageId
+import no.liflig.messaging.MessagePoller
+import no.liflig.messaging.MessagePollerObserver
+import no.liflig.messaging.ProcessingResult
+import no.liflig.messaging.chained
+import no.liflig.messaging.queue.MockQueue
+import org.junit.jupiter.api.Test
+
+internal class NoopObserver : MessagePollerObserver {
+  @Suppress("RedundantOverride")
+  override fun onPoll(messages: List<Message>) {
+    super.onPoll(messages)
+  }
+
+  override fun <ReturnT> wrapMessageProcessing(
+      message: Message,
+      messageProcessingBlock: () -> ReturnT,
+  ): ReturnT = messageProcessingBlock()
+
+  override fun <ReturnT> wrapPoller(pollerBlock: () -> ReturnT): ReturnT = pollerBlock()
+}
+
+internal class ChainedMessageObserverTest {
+  val queue = spyk(MockQueue())
+  val observer1 = spyk(NoopObserver())
+  val observer2 = spyk(NoopObserver())
+
+  val observer = chained(observer1, observer2)
+  val poller =
+      MessagePoller(
+          queue,
+          { m ->
+            if (m.body == "success") {
+              ProcessingResult.Success
+            } else {
+              ProcessingResult.Failure(false)
+            }
+          },
+          observer = observer,
+      )
+  val message =
+      Message(
+          id = MessageId("123"),
+          body = "success",
+          systemAttributes = emptyMap(),
+          customAttributes = emptyMap(),
+      )
+
+  @Test
+  fun `test onPoll`() {
+    queue.sentMessages.addLast(message)
+
+    poller.poll()
+    verifyOrder {
+      queue.poll()
+      observer1.onPoll(eq(listOf(message)))
+      observer2.onPoll(eq(listOf(message)))
+    }
+  }
+
+  @Test
+  fun `test wrapMessageProcessing order`() {
+    queue.sentMessages.addLast(message)
+
+    poller.poll()
+    verifyOrder {
+      queue.poll()
+      observer1.wrapMessageProcessing<Boolean>(message, any())
+      observer2.wrapMessageProcessing<Boolean>(message, any())
+    }
+  }
+
+  @Test
+  fun `test wrapPoller order`() {
+    queue.sentMessages.addLast(message)
+
+    poller.start()
+    queue.awaitProcessed(1)
+    verifyOrder {
+      observer1.wrapPoller<Boolean>(any())
+      observer2.wrapPoller<Boolean>(any())
+      queue.poll()
+    }
+    poller.close()
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
     <!-- Logging -->
     <slf4j.version>2.0.18</slf4j.version>
     <liflig-logging.version>3.20260603.090535</liflig-logging.version>
+    <opentelemetry.version>1.64.0</opentelemetry.version>
 
     <!-- Serialization -->
     <kotlinx-serialization.version>1.8.0</kotlinx-serialization.version>
@@ -95,6 +96,13 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>io.opentelemetry</groupId>
+        <artifactId>opentelemetry-bom</artifactId>
+        <version>${opentelemetry.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
 
       <!-- Testing -->
       <dependency>
@@ -114,6 +122,10 @@
       <artifactId>liflig-logging</artifactId>
       <version>${liflig-logging.version}</version>
     </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-api</artifactId>
+    </dependency>
 
     <!-- Testing -->
     <dependency>
@@ -131,6 +143,12 @@
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <version>${awaitility.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.mockk</groupId>
+      <artifactId>mockk-jvm</artifactId>
+      <version>1.14.11</version>
       <scope>test</scope>
     </dependency>
     <!-- Logging for tests -->


### PR DESCRIPTION
- Adds a `context` field to the core `Message` class to carry OpenTelemetry trace context
- Populates the `context` in `SqsQueue` from X-Ray trace headers
- Adds a new `OpenTelemetryMessagePollerObserver` that wraps message processing with an appropriate span
- Adds a new `ChainedMessagePollerObserver` to make it possible to use multiple observers for the same `MessagePoller`, i.e., to use OpenTelemetry and liflig-logging at the same time.