### PR TITLE
Add backoff field to ProcessingResult

### DIFF
--- a/liflig-messaging-core/src/main/kotlin/no/liflig/messaging/MessagePoller.kt
+++ b/liflig-messaging-core/src/main/kotlin/no/liflig/messaging/MessagePoller.kt
@@ -2,12 +2,15 @@
 
 package no.liflig.messaging
 
+import java.time.Duration
+import java.time.Instant
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.ThreadFactory
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.locks.ReentrantLock
 import java.util.function.Predicate
-import kotlin.time.Duration.Companion.seconds
+import kotlin.concurrent.withLock
 import no.liflig.logging.getLogger
 import no.liflig.messaging.observability.OpenTelemetryMessagePollerObserver
 import no.liflig.messaging.queue.Queue
@@ -42,9 +45,13 @@ public class MessagePoller(
             loggingMode = queue.observer?.loggingMode ?: MessageLoggingMode.JSON,
         ),
     private val stopPredicate: Predicate<Throwable>? = null,
+    private val sleep: (Long) -> Unit = Thread::sleep,
 ) : AutoCloseable {
   private val executor: ExecutorService =
       Executors.newFixedThreadPool(concurrentPollers, MessagePollerThreadFactory(namePrefix = name))
+
+  private val lock = ReentrantLock()
+  private var delayNextPollUntil: Instant? = null
 
   /**
    * Spawns a number of threads equal to [concurrentPollers] (default 1). Each thread continuously
@@ -64,25 +71,56 @@ public class MessagePoller(
   private fun runPollLoop() {
     observer.wrapPoller {
       while (!isStopped()) {
-        try {
-          poll()
-        } catch (e: Throwable) {
-          if (isStopped(cause = e)) {
-            break
-          }
+        val delayNextPoll: Duration =
+            try {
+              poll()
+            } catch (e: Throwable) {
+              if (isStopped(cause = e)) {
+                break
+              }
 
-          observer.onPollException(e)
+              observer.onPollException(e)
 
-          /** See [POLLER_RETRY_TIMEOUT]. */
-          Thread.sleep(POLLER_RETRY_TIMEOUT.inWholeMilliseconds)
-        }
+              /** See [POLLER_RETRY_TIMEOUT]. */
+              POLLER_RETRY_TIMEOUT
+            }
+
+        updateBackoff(delayNextPoll)?.let { sleep(it.toMillis()) }
       }
     }
   }
 
-  internal fun poll() {
+  /**
+   * Takes the wanted backoff from a [poll] invocation, and returns the actual duration the poller
+   * thread should wait. All poller threads will wait at least that long on next invocation.
+   *
+   * This should ensure that concurrent pollers cooperate and agree on how long to pause polling. If
+   * poller A wants to wait 10 seconds, and poller B returns 1 second later and wants to continue
+   * immediately, then both pollers will respect poller A's decision.
+   */
+  private fun updateBackoff(backoff: Duration): Duration? {
+    val now = Instant.now()
+
+    lock.withLock {
+      now.plus(backoff).let {
+        if (delayNextPollUntil == null || it > delayNextPollUntil) {
+          delayNextPollUntil = it
+        }
+      }
+
+      return if (now >= delayNextPollUntil) {
+        delayNextPollUntil = null
+        null
+      } else {
+        Duration.between(now, delayNextPollUntil)
+      }
+    }
+  }
+
+  internal fun poll(): Duration {
     val messages = queue.poll()
     observer.onPoll(messages)
+    var nextDelay = Duration.ZERO
 
     for (message in messages) {
       val stopped: Boolean =
@@ -97,6 +135,11 @@ public class MessagePoller(
                 }
                 is ProcessingResult.Failure -> {
                   observer.onMessageFailure(message, result)
+
+                  if (nextDelay < result.backoff) {
+                    nextDelay = result.backoff
+                  }
+
                   if (result.retry) {
                     queue.retry(message)
                   } else {
@@ -116,9 +159,10 @@ public class MessagePoller(
             }
           }
       if (stopped) {
-        return
+        break
       }
     }
+    return nextDelay
   }
 
   /** Stops all poller threads currently running. Does not wait for them to shut down. */
@@ -162,7 +206,7 @@ public class MessagePoller(
      * a temporary problem (such as a network failure), because `Queue.poll` can already take up to
      * 20 seconds when polling. So delaying further polling by 10 seconds should not be an issue.
      */
-    internal val POLLER_RETRY_TIMEOUT = 10.seconds
+    internal val POLLER_RETRY_TIMEOUT = Duration.ofSeconds(10)
   }
 }
 

--- a/liflig-messaging-core/src/main/kotlin/no/liflig/messaging/MessagePollerObserver.kt
+++ b/liflig-messaging-core/src/main/kotlin/no/liflig/messaging/MessagePollerObserver.kt
@@ -133,7 +133,7 @@ public open class DefaultMessagePollerObserver(
 
   override fun onPollException(exception: Throwable) {
     logger.error(exception) {
-      "Failed to poll messages. Retrying in ${MessagePoller.POLLER_RETRY_TIMEOUT.inWholeSeconds} seconds"
+      "Failed to poll messages. Retrying in ${MessagePoller.POLLER_RETRY_TIMEOUT.toSeconds()} seconds"
     }
   }
 

--- a/liflig-messaging-core/src/main/kotlin/no/liflig/messaging/MessageProcessor.kt
+++ b/liflig-messaging-core/src/main/kotlin/no/liflig/messaging/MessageProcessor.kt
@@ -1,5 +1,6 @@
 package no.liflig.messaging
 
+import java.time.Duration
 import no.liflig.logging.LogLevel
 
 /**
@@ -33,5 +34,8 @@ public sealed class ProcessingResult {
        * lower this if it represents an expected failure.
        */
       val severity: LogLevel = LogLevel.ERROR,
+
+      /** Signal to the [MessagePoller] that it should delay fetching the next batch. */
+      val backoff: Duration = Duration.ZERO,
   ) : ProcessingResult()
 }

--- a/liflig-messaging-core/src/test/kotlin/no/liflig/messaging/MessagePollerObserverTest.kt
+++ b/liflig-messaging-core/src/test/kotlin/no/liflig/messaging/MessagePollerObserverTest.kt
@@ -15,8 +15,7 @@ import no.liflig.messaging.testutils.TestMessage
 import no.liflig.messaging.testutils.TestMessagePollerObserver
 import no.liflig.messaging.testutils.TestMessageProcessor
 import org.awaitility.Awaitility.await
-import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -24,26 +23,19 @@ import org.junit.jupiter.api.TestInstance
 private val log = getLogger()
 
 /** Test if MessagePoller correctly invokes the observer */
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
 internal class MessagePollerObserverTest {
   val queue = MockQueue()
   val testProcessor = TestMessageProcessor()
   val observer = TestMessagePollerObserver()
-  val messagePoller = MessagePoller(queue, testProcessor, observer = observer)
+  val messagePoller = MessagePoller(queue, testProcessor, observer = observer, sleep = {})
 
-  @BeforeAll
+  @BeforeEach
   fun setup() {
     messagePoller.start()
   }
 
-  @BeforeEach
-  fun reset() {
-    queue.sentMessages.clear()
-    testProcessor.reset()
-    observer.reset()
-  }
-
-  @AfterAll
+  @AfterEach
   fun tearDown() {
     messagePoller.close()
   }
@@ -99,10 +91,10 @@ internal class MessagePollerObserverTest {
 
   @Test
   fun `invokes onStartup`() {
-    MessagePoller(queue, testProcessor, observer = observer).use {
-      messagePoller.start()
-
-      observer.startupCount shouldBe 1
+    val obs = TestMessagePollerObserver()
+    MessagePoller(queue, testProcessor, observer = obs).use {
+      it.start()
+      obs.startupCount shouldBe 1
     }
   }
 
@@ -121,13 +113,10 @@ internal class MessagePollerObserverTest {
 
     var loggingContext: LoggingContext? = null
 
-    val processor =
-        object : MessageProcessor {
-          override fun process(message: Message): ProcessingResult {
-            loggingContext = getCopyOfLoggingContext()
-            return ProcessingResult.Success
-          }
-        }
+    val processor = MessageProcessor {
+      loggingContext = getCopyOfLoggingContext()
+      ProcessingResult.Success
+    }
 
     val queue = MockQueue()
 

--- a/liflig-messaging-core/src/test/kotlin/no/liflig/messaging/MessagePollerTest.kt
+++ b/liflig-messaging-core/src/test/kotlin/no/liflig/messaging/MessagePollerTest.kt
@@ -2,6 +2,8 @@ package no.liflig.messaging
 
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicLong
 import no.liflig.messaging.queue.MockQueue
 import no.liflig.messaging.testutils.TestMessage
 import no.liflig.messaging.testutils.TestMessagePollerObserver
@@ -35,7 +37,7 @@ internal class MessagePollerTest {
 
   @Test
   fun `stopPredicate can stop poller thread`() {
-    var observer = TestMessagePollerObserver()
+    val observer = TestMessagePollerObserver()
 
     MessagePoller(queue, testProcessor, observer = observer, stopPredicate = { true }).use {
         messagePoller ->
@@ -45,5 +47,79 @@ internal class MessagePollerTest {
 
       await().until { observer.threadStoppedCount > 0 }
     }
+  }
+
+  @Test
+  fun `test backoff`() {
+    val queue = MockQueue()
+    val slept = AtomicLong(0)
+
+    MessagePoller(
+            queue = queue,
+            messageProcessor = { _ ->
+              ProcessingResult.Failure(retry = false, backoff = Duration.ofSeconds(17))
+            },
+            sleep = slept::addAndGet,
+        )
+        .use { messagePoller ->
+          messagePoller.start()
+
+          queue.send("1")
+          queue.awaitFailedWithoutRetry(1)
+          queue.send("2")
+          queue.awaitFailedWithoutRetry(1)
+          queue.send("3")
+          queue.awaitFailedWithoutRetry(1)
+        }
+
+    slept.get() shouldBe (17000 * 3)
+  }
+
+  @Test
+  fun `test batched backoff`() {
+    val queue = MockQueue()
+    val slept = AtomicLong(0)
+
+    MessagePoller(
+            queue = queue,
+            messageProcessor = { _ ->
+              ProcessingResult.Failure(retry = false, backoff = Duration.ofSeconds(17))
+            },
+            sleep = slept::addAndGet,
+        )
+        .use { messagePoller ->
+          queue.send("1")
+          queue.send("2")
+          queue.send("3")
+
+          messagePoller.start()
+
+          queue.awaitFailedWithoutRetry(3)
+        }
+
+    slept.get() shouldBe (17000)
+  }
+
+  @Test
+  fun `test no backoff`() {
+    val queue = MockQueue()
+    val slept = AtomicLong(0)
+
+    MessagePoller(
+            queue = queue,
+            messageProcessor = { _ -> ProcessingResult.Failure(retry = false) },
+            sleep = slept::addAndGet,
+        )
+        .use { messagePoller ->
+          messagePoller.start()
+
+          queue.send("1")
+          queue.send("2")
+          queue.send("3")
+
+          queue.awaitFailedWithoutRetry(3)
+        }
+
+    slept.get() shouldBe (0)
   }
 }


### PR DESCRIPTION
Allows `MessageProcessor` implementations to signal that the `MessagePoller` should delay the next poll. This avoids pulling messages from the queue if we know that we're not ready for processing them, e.g., if we are being rate limited or if an external service is down.